### PR TITLE
Fix clippy warnings-

### DIFF
--- a/src/experiments/discovery.rs
+++ b/src/experiments/discovery.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 use async_std::task::{block_on, spawn};
 use futures::stream::{FuturesUnordered, StreamExt};
 use lambda_calculus::{

--- a/src/experiments/distribution.rs
+++ b/src/experiments/distribution.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 use std::collections::HashMap;
 
 use lambda_calculus::Term;

--- a/src/experiments/entropy.rs
+++ b/src/experiments/entropy.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 use async_std::task::{block_on, spawn};
 use futures::{stream::FuturesUnordered, StreamExt};
 use lambda_calculus::Term;

--- a/src/experiments/kinetics.rs
+++ b/src/experiments/kinetics.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 use async_std::task::{block_on, spawn};
 use futures::stream::{FuturesUnordered, StreamExt};
 use lambda_calculus::{data::num::church::succ, Term};

--- a/src/experiments/magic_test_function.rs
+++ b/src/experiments/magic_test_function.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 use async_std::task::{block_on, spawn};
 use futures::{stream::FuturesUnordered, StreamExt};
 use lambda_calculus::reduction::Order::HAP;

--- a/src/experiments/mod.rs
+++ b/src/experiments/mod.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 pub mod entropy;
 
 pub mod search_by_behavior;

--- a/src/experiments/search_by_behavior.rs
+++ b/src/experiments/search_by_behavior.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![allow(warnings)]
+
 use async_std::task::{block_on, spawn};
 use futures::{stream::FuturesUnordered, StreamExt};
 use lambda_calculus::{app, Term};

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -82,6 +82,12 @@ pub struct BTreeGen {
     rng: ChaCha8Rng,
 }
 
+impl Default for BTreeGen {
+    fn default() -> BTreeGen {
+        Self::new()
+    }
+}
+
 impl BTreeGen {
     pub fn new() -> BTreeGen {
         BTreeGen::from_config(&config::BTreeGen::new())
@@ -146,6 +152,7 @@ impl BTreeGen {
     }
 }
 
+#[allow(dead_code)]
 pub struct FontanaGen {
     abs_range: (f64, f64),
     app_range: (f64, f64),

--- a/src/lambda/core.rs
+++ b/src/lambda/core.rs
@@ -247,6 +247,12 @@ impl fmt::Display for LambdaParticle {
     }
 }
 
+impl Default for LambdaSoup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LambdaSoup {
     /// Generate an empty soup with the following configuration options:
     pub fn new() -> Self {

--- a/src/lambda/mod.rs
+++ b/src/lambda/mod.rs
@@ -1,4 +1,4 @@
-pub mod lambda;
+pub mod core;
 
 pub mod recursive;
 

--- a/src/lambda/recursive.rs
+++ b/src/lambda/recursive.rs
@@ -94,8 +94,8 @@ fn uses_both_arguments_helper(expr: &Term, depth: usize) -> (bool, bool) {
         Term::Abs(ref boxed) => uses_both_arguments_helper(boxed, depth + 1),
         Term::App(ref boxed) => {
             let (ref left, ref right) = **boxed;
-            let (l0, l1) = uses_both_arguments_helper(&left, depth);
-            let (r0, r1) = uses_both_arguments_helper(&right, depth);
+            let (l0, l1) = uses_both_arguments_helper(left, depth);
+            let (r0, r1) = uses_both_arguments_helper(right, depth);
             (l0 || r0, l1 || r1)
         }
         Term::Var(n) => (*n == depth, *n == depth - 1),
@@ -257,11 +257,11 @@ impl Collider<LambdaParticle, LambdaCollisionOk, LambdaCollisionError> for Alche
         left: LambdaParticle,
         right: LambdaParticle,
     ) -> Result<LambdaCollisionOk, LambdaCollisionError> {
-        return if left.recursive {
+        if left.recursive {
             self.recursive_collide(left, right)
         } else {
             self.nonrecursive_collide(left, right)
-        };
+        }
     }
 }
 

--- a/src/supercollider.rs
+++ b/src/supercollider.rs
@@ -223,6 +223,10 @@ where
         self.expressions.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.expressions.is_empty()
+    }
+
     /// Get the number of successful collisions
     pub fn collisions(&self) -> usize {
         self.n_collisions

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,7 +97,7 @@ where
     U: Ord,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.priority.cmp(&other.priority))
+        Some(self.cmp(other))
     }
 }
 
@@ -144,6 +144,6 @@ where
     for i in series {
         write!(file, "{:?}; ", i)?;
     }
-    write!(file, "\n")?;
+    writeln!(file)?;
     Ok(())
 }


### PR DESCRIPTION
@devyanshnegi fixed clippy warnings, mostly by ignoring issues in experiments. This seems to be passing the test, so I'm gonna merge into the `cherry-pick-bss-files` branch. 