### PR TITLE
Cleanup/dead code removal

### DIFF
--- a/src/lambda/mod.rs
+++ b/src/lambda/mod.rs
@@ -1,4 +1,4 @@
-pub mod core;
+// pub mod core; // superseded by recursive.rs — no callers remain
 
 pub mod recursive;
 

--- a/src/lambda/recursive.rs
+++ b/src/lambda/recursive.rs
@@ -22,7 +22,6 @@ pub struct LambdaParticle {
 pub struct AlchemyCollider {
     rlimit: usize,
     slimit: usize,
-    disallow_recursive: bool,
     reaction_rules: Vec<Term>,
     discard_copy_actions: bool,
     discard_identity: bool,
@@ -134,7 +133,6 @@ impl AlchemyCollider {
         Self {
             rlimit: cfg.reduction_cutoff,
             slimit: cfg.size_cutoff,
-            disallow_recursive: false,
             reaction_rules: cfg
                 .rules
                 .iter()

--- a/src/python.rs
+++ b/src/python.rs
@@ -109,11 +109,55 @@ pub struct PyReactor {
 
 #[pymethods]
 impl PyReactor {
+    /// Create a reactor.
+    ///
+    /// All arguments are keyword-only and optional. Defaults match `Reactor::new()`:
+    ///   - rules                            = ["\\x.\\y.x y"]
+    ///   - discard_copy_actions             = True
+    ///   - discard_identity                 = True
+    ///   - discard_free_variable_expressions= True
+    ///   - maintain_constant_population_size= True
+    ///   - discard_parents                  = False
+    ///   - reduction_cutoff                 = 500
+    ///   - size_cutoff                      = 500
+    ///   - seed                             = None  (random)
     #[new]
-    fn new() -> Self {
-        PyReactor {
-            inner: RustReactor::new(),
-        }
+    #[pyo3(signature = (
+        rules=None,
+        discard_copy_actions=true,
+        discard_identity=true,
+        discard_free_variable_expressions=true,
+        maintain_constant_population_size=true,
+        discard_parents=false,
+        reduction_cutoff=500,
+        size_cutoff=500,
+        seed=None,
+    ))]
+    fn new(
+        rules: Option<Vec<String>>,
+        discard_copy_actions: bool,
+        discard_identity: bool,
+        discard_free_variable_expressions: bool,
+        maintain_constant_population_size: bool,
+        discard_parents: bool,
+        reduction_cutoff: usize,
+        size_cutoff: usize,
+        seed: Option<String>,
+    ) -> PyResult<Self> {
+        let seed_bytes = parse_seed(seed)?;
+        Ok(PyReactor {
+            inner: RustReactor {
+                rules: rules.unwrap_or_else(|| vec![String::from("\\x.\\y.x y")]),
+                discard_copy_actions,
+                discard_identity,
+                discard_free_variable_expressions,
+                maintain_constant_population_size,
+                discard_parents,
+                reduction_cutoff,
+                size_cutoff,
+                seed: ConfigSeed::new(seed_bytes),
+            },
+        })
     }
 }
 

--- a/src/supercollider.rs
+++ b/src/supercollider.rs
@@ -80,6 +80,7 @@ where
         let result = self.collider.collide(left.clone(), right.clone());
 
         if let Ok(ref t) = result {
+            self.n_collisions += 1;
             self.perturb(t.particles());
 
             // Remove additional expressions, if required.


### PR DESCRIPTION
## Summary 
- **Remove `lambda::core` module** — `lambda/core.rs` (the non-recursive predecessor to `recursive.rs`) had no callers anywhere in the codebase. Commented out `pub mod core` in `lambda/mod.rs`. 
- **Fix `n_collisions` counter** — `Soup::react()` never incremented `n_collisions`, so `collisions()` always returned 0. This also affected `PySoup.collisions()` in the Python bindings. 
- **Expose full `Reactor` configuration on `PyReactor`** — previously a no-arg stub; now accepts all reactor fields as keyword arguments with defaults matching `Reactor::new()`, so existing scripts are unaffected. 
- **Remove dead `disallow_recursive` field** — was hardcoded to `false` in `from_config` and never read by any collision logic. The intended kill-switch behaviour is redundant since callers simply don't call `add_test_expressions()`. 

- ## Test plan 
- [ ] `cargo build` passes cleanly 
- [ ] Existing `test_alchemy.py` passes (no API breakage — `PyReactor()` with no args still works)
- [ ]  `PySoup.collisions()` now returns a non-zero value after reactions 
- [ ] `PyReactor(reduction_cutoff=8000, size_cutoff=1000, ...)` configures the reactor correctly 

🤖 Generated with [Claude Code](https://claude.com/claude-code)